### PR TITLE
Bug/modify shipping response

### DIFF
--- a/src/components/CartCheckout.js
+++ b/src/components/CartCheckout.js
@@ -11,7 +11,6 @@ import { ReactComponent as ArrowIcon } from '../assets/arrow-icon.svg';
 import pairShoes from '../assets/pair-shoes-small.png'
 import sockImage from '../assets/updated-sock-image.png'
 
-
 function CartLineItem(props) {
   return (
     <div className="">
@@ -52,7 +51,6 @@ function CartLineItem(props) {
     </div>
   )
 }
-
 
 class CartCheckout extends Component {
 
@@ -134,7 +132,6 @@ class CartCheckout extends Component {
   }
 
   getAllCountries() {
-
     this.props.commerce.services.localeListCountries().then(resp => {
       this.setState({
         countries: resp.countries
@@ -145,7 +142,6 @@ class CartCheckout extends Component {
   }
 
   getRegions(countryCode) {
-
     this.props.commerce.services.localeListSubdivisions(countryCode).then(resp => {
       this.setState({
         subdivisions: resp.subdivisions
@@ -157,7 +153,6 @@ class CartCheckout extends Component {
 
   // checkout methods
   createCheckout(e) {
-
     if (e) {
       e.preventDefault()
     }
@@ -368,7 +363,6 @@ class CartCheckout extends Component {
       }
     })
   }
-
 
   render() {
     const {

--- a/src/components/CartCheckout.js
+++ b/src/components/CartCheckout.js
@@ -179,10 +179,9 @@ class CartCheckout extends Component {
 
   getShippingOptions(checkoutId, country) {
     this.props.commerce.checkout.getShippingOptions(checkoutId, { country }).then(resp => {
-      const resValues = Object.values(resp)
         this.setState({
-          shippingOptions: resValues,
-          shippingOptionsById: resValues.reduce((obj, option) => {
+          shippingOptions: resp,
+          shippingOptionsById: resp.reduce((obj, option) => {
            obj[option.id] = option
            return obj
           }, {})


### PR DESCRIPTION
- removes redundant use of `object.values` since rgetShippingOptions response is an `array ` already