### PR TITLE
Bug - remove extra quotation mark in .chec.json  

### DIFF
--- a/.chec.json
+++ b/.chec.json
@@ -3,9 +3,7 @@
   "buildScripts": ["seed", "start"],
   "dotenv": {
     "NODE_ENV": "development",
-    "VUE_APP_COMMERCEJS_PUBLIC_KEY": ""%chec_pkey",
-    "REACT_APP_COMMERCEJS_PUBLIC_KEY": "%chec_pkey%",
-    "REACT_APP_COMMERCEJS_API_URL": "%chec_api_url%",
+    "VUE_APP_COMMERCEJS_PUBLIC_KEY": "%chec_pkey",
     "VUE_APP_CHEC_API_URL": "%chec_api_url%",
     "CHEC_SECRET_KEY": "%chec_skey%",
     "CHEC_API_URL": "%chec_api_url%"


### PR DESCRIPTION
- allow Chec CLI demo-store command to work for vue.js shoe store by removing unexpected token from `.chec.json` 
- removed 'react.js' env variables not needed in vue.js shoe-store