### PR TITLE
CSS Fixed overflow scroll on cart and form

### DIFF
--- a/src/components/CartCheckout.js
+++ b/src/components/CartCheckout.js
@@ -435,7 +435,7 @@ class CartCheckout extends Component {
         </div>
         <div className="cf mw9 center w-100 ph3 mt5">
             <div className="fl w-100 w-40-l ph2 ph4-l mb4">
-                <div className="relative z-1 br3 bg-dark-gray w-100 shadow-3 pv4 overflow-scroll">
+                <div className="relative z-1 br3 bg-dark-gray w-100 shadow-3 pv4 overflow-hidden">
                   {allLineItems}
                 </div>
                 <div className="pt4 pb3 nt3 br3 ph4 bg-cherry">

--- a/src/components/CartCheckout.js
+++ b/src/components/CartCheckout.js
@@ -435,7 +435,7 @@ class CartCheckout extends Component {
         </div>
         <div className="cf mw9 center w-100 ph3 mt5">
             <div className="fl w-100 w-40-l ph2 ph4-l mb4">
-                <div className="relative z-1 br3 bg-dark-gray w-100 shadow-3 pv4 overflow-hidden">
+                <div className="relative z-1 br3 bg-dark-gray w-100 shadow-3 pv4">
                   {allLineItems}
                 </div>
                 <div className="pt4 pb3 nt3 br3 ph4 bg-cherry">

--- a/src/components/ThankYou.js
+++ b/src/components/ThankYou.js
@@ -34,7 +34,7 @@ class ThankYou extends Component {
       <div className="flex flex-grow-1 bg-tan-white w-100 pt6 pb5">
         <div className="cf flex flex-column flex-row-l mw9 center w-100 ph3 mt5">
           <div className="fl w-100 w-40-l ph3">
-              <div className="relative z-1 h5 br3 bg-dark-gray w-100 shadow-3 pt2 overflow-scroll">
+              <div className="relative z-1 h5 br3 bg-dark-gray w-100 shadow-3 pt2 overflow-hidden">
                 {allLineItems}
               </div>
               <div className="pt4 pb3 nt3 br3 ph4 bg-cherry">

--- a/src/components/ThankYou.js
+++ b/src/components/ThankYou.js
@@ -34,7 +34,7 @@ class ThankYou extends Component {
       <div className="flex flex-grow-1 bg-tan-white w-100 pt6 pb5">
         <div className="cf flex flex-column flex-row-l mw9 center w-100 ph3 mt5">
           <div className="fl w-100 w-40-l ph3">
-              <div className="relative z-1 h5 br3 bg-dark-gray w-100 shadow-3 pt2 overflow-hidden">
+              <div className="relative z-1 h5 br3 bg-dark-gray w-100 shadow-3 pt2">
                 {allLineItems}
               </div>
               <div className="pt4 pb3 nt3 br3 ph4 bg-cherry">

--- a/src/styles/modules/_elements.scss
+++ b/src/styles/modules/_elements.scss
@@ -69,7 +69,6 @@
   @extend .ttu !optional;
   @extend .pb2 !optional;
   @extend .nowrap !optional;
-  @extend .overflow-hidden !optional;
 }
 
 .chooseASize {

--- a/src/styles/modules/_elements.scss
+++ b/src/styles/modules/_elements.scss
@@ -69,7 +69,7 @@
   @extend .ttu !optional;
   @extend .pb2 !optional;
   @extend .nowrap !optional;
-  @extend .overflow-scroll !optional;
+  @extend .overflow-hidden !optional;
 }
 
 .chooseASize {


### PR DESCRIPTION
Changed overflow scroll to hidden for cart items and checkout form because inheritance of overflow-x-hidden class doesn't always work.